### PR TITLE
add Path object support

### DIFF
--- a/bagpy/bagreader.py
+++ b/bagpy/bagreader.py
@@ -39,6 +39,7 @@ import time
 from io import BytesIO
 import csv
 import inspect
+from os import PathLike
 
 import rosbag
 from std_msgs.msg import String, Header
@@ -57,7 +58,6 @@ import pickle
 from packaging import version
 
 from pathlib import Path
-from transparentpath import Path as TPath
 version_src = ''
 
 try:
@@ -138,9 +138,9 @@ class bagreader:
 
     Parameters
     ----------------
-    bagfile: `string` | `Path` | `transparentpath` | `file stream`
+    bagfile: `string` | `pathlike` | `file stream`
         Bagreader constructor takes the path to a bagfile to open. This path may be relative or absolute and may be provide 
-        via a string, Path object or transparent path object. Additionally instead of providing a file path, a file stream 
+        via a string, Pathlike object. Additionally instead of providing a file path, a file stream 
         or buffer stream can be provided. If the bagfile argument is a file or buffer stream, the datafolder parameter must be used.
     
     delimiter: `string`
@@ -152,8 +152,8 @@ class bagreader:
     tmp: `bool`
         If True, creates directory in /tmp folder. Default: `False`
 
-    datafolder: `Path`
-        A file path or transparent path to the folder where the bag file can be extracted. If left None a folder will be created next 
+    datafolder: `Pathlike`
+        A file pathlike to the folder where the bag file can be extracted. If left None a folder will be created next 
         to the given bagfile with the same name as the bagfile. 
 
     Attributes
@@ -204,10 +204,10 @@ class bagreader:
             self.bagfile = Path(bagfile)
 
         # determine the directory
-        assert type(self.bagfile) in [Path, TPath] or datafolder is not None, "Either the bag file must be a file path or a file path must be given in datafolder"
+        # assert type(self.bagfile) in [Path, PathLike] or datafolder is not None, "Either the bag file must be a file path or a file path must be given in datafolder"
         if datafolder is not None:
             self.datafolder = datafolder.absolute
-        elif type(self.bagfile) in [Path, TPath]:
+        else:
             self.datafolder = self.bagfile.absolute.parent / self.bagfile.stem
 
         self.reader = rosbag.Bag(self.bagfile)

--- a/bagpy/bagreader.py
+++ b/bagpy/bagreader.py
@@ -57,6 +57,8 @@ import pickle
 
 from packaging import version
 
+from cloudUtils import open_cloud_save as open
+
 from pathlib import Path
 version_src = ''
 

--- a/bagpy/bagreader.py
+++ b/bagpy/bagreader.py
@@ -196,7 +196,7 @@ class bagreader:
 
     '''
 
-    def __init__(self , bagfile , delimiter=",", verbose=True , tmp = False, datafolder: Path = None):
+    def __init__(self , bagfile , delimiter=",", verbose=True , tmp = False, datafolder: PathLike = None):
         self.bagfile = bagfile
         self.delimiter = delimiter
         
@@ -206,9 +206,9 @@ class bagreader:
         # determine the directory
         # assert type(self.bagfile) in [Path, PathLike] or datafolder is not None, "Either the bag file must be a file path or a file path must be given in datafolder"
         if datafolder is not None:
-            self.datafolder = datafolder.absolute
+            self.datafolder = datafolder.absolute()
         else:
-            self.datafolder = self.bagfile.absolute.parent / self.bagfile.stem
+            self.datafolder = self.bagfile.absolute().parent / self.bagfile.stem
 
         self.reader = rosbag.Bag(self.bagfile)
 

--- a/bagpy/bagreader.py
+++ b/bagpy/bagreader.py
@@ -57,7 +57,7 @@ import pickle
 
 from packaging import version
 
-from cloudUtils import open_cloud_save as open
+from .cloudUtils import open_cloud_save as open
 
 from pathlib import Path
 version_src = ''

--- a/bagpy/cloudUtils.py
+++ b/bagpy/cloudUtils.py
@@ -1,0 +1,6 @@
+from cloudpathlib import GSPath
+
+def open_cloud_save(path, *args, **kwargs):
+    if type(path) == GSPath:
+        return path.open(*args, **kwargs)
+    return open(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,3 @@ nbsphinx
 pandoc
 pandocfilters
 yolk3k
-transparentpath

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ nbsphinx
 pandoc
 pandocfilters
 yolk3k
+cloudpathlib[gs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ nbsphinx
 pandoc
 pandocfilters
 yolk3k
+transparentpath


### PR DESCRIPTION
File path are now represented by Path objects instead of strings. In combination with transparent path this allows for seamless switching between google storage and local files. With the optional datafolder parameter, the bag file can even be a file object or buffer object. This allows for integration with more foreign storage solutions