### PR TITLE
Remove the version restriction on jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyyaml
 rospkg
 ipython
 py3rosmsgs
-jinja2<3.1
+jinja2
 pytest
 pandas
 setuptools-scm

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ required_packages=[
         'rospkg',
         'ipython',
         'py3rosmsgs',
-        'jinja2<3.1',
+        'jinja2',
         'pytest',
         'pandas',
         'setuptools-scm',


### PR DESCRIPTION
This dependency is causing issues with our existing dependencies. Is it possible to remove this restriction?